### PR TITLE
Update Microsoft.IdentityModel.Clients.ActiveDirectory for CVE-2019-1258

### DIFF
--- a/Sharing/SharingServiceSample/SharingService.csproj
+++ b/Sharing/SharingServiceSample/SharingService.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
   </ItemGroup>


### PR DESCRIPTION
  - This change updates the version of Microsoft.IdentityModel.Clients.ActiveDirectory currently used (4.5.0) in the sharing service to 5.2.0, which contains a fix for CVE-2019-1258.