### PR TITLE
Enabling Unity_Standalone builds

### DIFF
--- a/Unity/Assets/AzureSpatialAnchors.SDK/Plugins/Common/AzureSpatialAnchorsBridge.cs
+++ b/Unity/Assets/AzureSpatialAnchors.SDK/Plugins/Common/AzureSpatialAnchorsBridge.cs
@@ -10367,8 +10367,8 @@ namespace Microsoft.Azure.SpatialAnchors
 
 }
 
-#elif UNITY_EDITOR
-// Making calls to Azure Spatial Anchors from the Unity editor is not currently supported.
+#elif UNITY_EDITOR || UNITY_STANDALONE
+// Making calls to Azure Spatial Anchors from the Unity editor or Unity Standalone is not currently supported.
 // These stubs are here to prevent the editor from reporting compilation errors.
 //
 // AzureSpatialAnchors


### PR DESCRIPTION
For some Scenarios (including Spectator View pro) it is useful to have the Application running as Standalone Build outside of Unity. 
Of course, the Anchor part will not work.
Please note: in the code is mentioned that this file is generated by SscApiModelDirect.cs.. which I seem to not have access to.