### PR TITLE
Fixed SessionDestroyed signal

### DIFF
--- a/Unity/Assets/AzureSpatialAnchors.SDK/Scripts/CloudNativeAnchor.cs
+++ b/Unity/Assets/AzureSpatialAnchors.SDK/Scripts/CloudNativeAnchor.cs
@@ -74,7 +74,9 @@ namespace Microsoft.Azure.SpatialAnchors.Unity
 
             // Apply and store updated native anchor
             nativeAnchor = gameObject.ApplyCloudAnchor(cloudAnchor);
+            this.cloudAnchor = cloudAnchor;
         }
+
 
         /// <summary>
         /// Creates or updates the <see cref="CloudSpatialAnchor"/> returned by

--- a/Unity/Assets/AzureSpatialAnchors.SDK/Scripts/SpatialAnchorManager.cs
+++ b/Unity/Assets/AzureSpatialAnchors.SDK/Scripts/SpatialAnchorManager.cs
@@ -802,6 +802,8 @@ namespace Microsoft.Azure.SpatialAnchors.Unity
             // Reset session status as well
             sessionStatus = null;
 
+            // Notify
+            OnSessionDestroyed();
         }
 
         /// <summary>


### PR DESCRIPTION
I was wondering why the SessionDestroyed event in SpatialAnchorManager was not signaling, but it turns out that someone forgot to add OnSessionDestroyed() to the end of DestroySession().