### PR TITLE
Put the StorageConnectionString back

### DIFF
--- a/Sharing/SharingServiceSample/appsettings.json
+++ b/Sharing/SharingServiceSample/appsettings.json
@@ -6,5 +6,6 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "StorageConnectionString": ""
 }


### PR DESCRIPTION
This change puts the `StorageConnectionString` back since it is expected to be there for the CosmosDB tutorial.